### PR TITLE
Comment out RaygunErrorModules

### DIFF
--- a/RaygunTest/Web.config
+++ b/RaygunTest/Web.config
@@ -25,9 +25,10 @@
   <system.web>
     <compilation debug="true" targetFramework="4.7.2" />
     <httpRuntime targetFramework="4.7.1" />
-    <httpModules>
+    <!--<httpModules>
       <add name="RaygunErrorModule" type="Mindscape.Raygun4Net.RaygunHttpModule"/>
     </httpModules>
+    -->
     <customErrors mode="On" defaultRedirect="~/Error/SomethingWentWrong">
       <error redirect="~/Error/PageNotFound" statusCode="404" />
       <error redirect="~/Error/SomethingWentWrong" statusCode="500" />
@@ -37,9 +38,8 @@
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <modules>
-      <add name="RaygunErrorModule" type="Mindscape.Raygun4Net.RaygunHttpModule"/>
+      <!-- <add name="RaygunErrorModule" type="Mindscape.Raygun4Net.RaygunHttpModule"/> -->
     </modules>
-
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
This PR removes the Raygun HTTPModules from the MVC web config.

By removing that, uncaught errors are passed to `Application_Error` by Global.asax.cs. Errors sent to Raygun will have the tags specified in the `SendInBackground` call added to them i.e. `WebUI`